### PR TITLE
References in paper.bib

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -21,7 +21,7 @@
 }
 
 @article{jordan2017analysis,
-  title={Analysis of the Carpentries' Long-Term Feedback Survey},
+  title={Analysis of {T}he {C}arpentries' Long-Term Feedback Survey},
   author={Jordan, Kari L and Marwick, Ben and Weaver, Belinda and Zimmerman, Naupaka and Williams, Jason and Teal, Tracy and Becker, Erin and Duckles, Jonah and Duckles, Beth and Wickes, Elizabeth},
   year         = 2017,
   publisher    = {Zenodo},
@@ -31,22 +31,26 @@
 }
 
 @misc{becker2021carpentries,
-  title={The carpentries curriculum development handbook},
+  title={{T}he {C}arpentries curriculum development handbook},
   author={Becker, Erin and Michonneau, Fran{\c{c}}ois},
   year={2021},
   url={https://cdh.carpentries.org}
 }
 
 @misc{carpentries2019git,
-  title={Software Carpentry: Version Control with Git},
-  author={Gonzalez,Ivan and Huang, Daisie and Hejazi, Nima and Koziar, Katherine and Munk, Madicken},
+  title={{S}oftware {C}arpentry: Version Control with {G}it},
+  editor={Gonzalez,Ivan and Huang, Daisie and Hejazi, Nima and Koziar, Katherine and Munk, Madicken},
   year={2019},
+  publisher={Zenodo},
+  doi={10.5281/zenodo.3264950},
   url={https://github.com/swcarpentry/git-novice}
 }
 
 @misc{carpentries2023projectorg,
-  title={Project Organization and Management for Genomics},
-  author={Hoyt, Peter and Steiner, Heidi and Szamosi, Jake},
+  title={{D}ata {C}arpentry: Genomics Organization Lesson.},
+  editor={Koziar, Katherine and Hejazi, Nima and Munk, Madicken and Gruber, Scott},
   year={2023},
+  publisher={Zenodo},
+  doi={10.5281/zenodo.7908089},
   url={https://datacarpentry.org/organization-genomics}
 }


### PR DESCRIPTION
Updated references in paper. bib to:
- have caps protect for The Carpentries etc
- correctly reference Carpentries lessons on zenodo w/dois
- when stated in citation files, have editor fields not author fields for Carpentries lessons